### PR TITLE
Update readme references to CICS to IMS and add health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Zowe CLI Plug-in for IBM® IMS® 
-The Zowe CLI Plug-in for IBM® IMS® lets you extend Zowe CLI to interact with IBM IMS programs and transactions. The plug-in uses the IBM IMS Management Client Interface (CMCI) API to achieve the interaction with IMS. For more information, see [IMS management client interface](https://www.ibm.com/support/knowledgecenter/en/SSGMCP_5.3.0/com.ibm.cics.ts.clientapi.doc/topics/clientapi_overview.html) on the IBM Knowledge Center.
+The Zowe CLI Plug-in for IBM® IMS® lets you extend Zowe CLI to interact with IBM IMS programs and transactions. The plug-in uses the IBM IMS Management Client Interface API to achieve the interaction with IMS. For more information, see [IMS management client interface](https://www.ibm.com/support/knowledgecenter/en/SSGMCP_5.3.0/com.ibm.cics.ts.clientapi.doc/topics/clientapi_overview.html) on the IBM Knowledge Center.
 
 As an application developer, you can use the plug-in to perform various IMS-related tasks, such as the following:
 
@@ -66,14 +66,14 @@ Before you install the plug-in, meet the following prerequisites:
 4.  [Create a user profile](#create-a-user-profile).
 
 ## Create a User Profile
-You can create a `ims` user profile to avoid typing your connection details on every command. A `cics` profile contains the host, port, username, and password for the IBM CMCI server of your choice. You can create multiple profiles and switch between them as needed.
+You can create an `ims` user profile to avoid typing your connection details on every command. An `ims` profile contains the host, port, username, and password for the IMS API server of your choice. You can create multiple profiles and switch between them as needed.
 
 **Follow these steps:**
 1.  Create a IMS profile: 
     ```
     zowe profiles create ims <profile name> <host> <port> <user> <password>
     ```
-    The result of the command displays as a success or failure message. You can use your profile when you issue commands in the cics command group.
+    The result of the command displays as a success or failure message. You can use your profile when you issue commands in the ims command group.
 
 **Tip:** For more information about the syntax, actions, and options, for a profiles create command, open Zowe CLI and issue the following command:
 

--- a/README.md
+++ b/README.md
@@ -50,35 +50,35 @@ Before you install the plug-in, meet the following prerequisites:
 1.  Meet the prerequisites.
 2.  Install the plug-in:
     ```
-    zowe plugins install @brightside/cics
+    zowe plugins install @zowe/ims
     ``` 
 3.  (Optional) Verify the installation:
     ```
-    zowe plugins validate @brightside/cics
+    zowe plugins validate @zowe/ims
     ```
     When you install the plug-in successfully, the following message displays:
     ```
-    Validation results for plugin 'cics':
-    Successfully validated.
+    _____ Validation results for plugin '@zowe/ims' _____
+    This plugin was successfully validated. Enjoy the plugin.
     ``` 
     **Tip:** When an unsuccessful message displays, you can troubleshoot the installation by addressing the issues that the message describes. You can also review the information that is contained in the log file that is located in the directory where you installed Zowe CLI.  
 
 4.  [Create a user profile](#create-a-user-profile).
 
 ## Create a User Profile
-You can create a `cics` user profile to avoid typing your connection details on every command. A `cics` profile contains the host, port, username, and password for the IBM CMCI server of your choice. You can create multiple profiles and switch between them as needed.
+You can create a `ims` user profile to avoid typing your connection details on every command. A `cics` profile contains the host, port, username, and password for the IBM CMCI server of your choice. You can create multiple profiles and switch between them as needed.
 
 **Follow these steps:**
 1.  Create a IMS profile: 
     ```
-    zowe profiles create cics <profile name> <host> <port> <user> <password>
+    zowe profiles create ims <profile name> <host> <port> <user> <password>
     ```
     The result of the command displays as a success or failure message. You can use your profile when you issue commands in the cics command group.
 
 **Tip:** For more information about the syntax, actions, and options, for a profiles create command, open Zowe CLI and issue the following command:
 
 ```
-zowe profiles create cics -h
+zowe profiles create ims -h
 ```
 
 ## Run Tests
@@ -90,7 +90,7 @@ For information about running automated, unit, and system and integration tests 
 **Follow these steps:**
 1.  To uninstall the plug-in from a base application, issue the following command:
     ```
-    zowe plugins uninstall @brightside/cics
+    zowe plugins uninstall @zowe/ims
     ```
 After the uninstallation process completes successfully, the product no longer contains the plug-in configuration.
 

--- a/src/healthCheck.ts
+++ b/src/healthCheck.ts
@@ -1,0 +1,19 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+/**
+ * Health check for the IMS plugin
+ * No-op health check to avoid an imperative plugin validation warning
+ */
+const healthCheck = () => {
+  return true;
+};
+export = healthCheck;

--- a/src/imperative.ts
+++ b/src/imperative.ts
@@ -14,75 +14,76 @@ import { IImperativeConfig } from "@brightside/imperative";
 import { PluginConstants } from "./api/constants/PluginConstants";
 
 const config: IImperativeConfig = {
-    commandModuleGlobs: ["**/cli/*/*.definition!(.d).*s"],
-    rootCommandDescription: PluginConstants.PLUGIN_DESCRIPTION,
-    productDisplayName: PluginConstants.PLUGIN_NAME,
-    name: PluginConstants.PLUGIN_GROUP_NAME,
-    profiles: [
-        {
-            type: "ims",
-            schema: {
-                type: "object",
-                title: "IMS Profile",
-                description: "A ims profile is required to issue commands in the ims command group that interact with " +
-                    "IMS regions. The ims profile contains your host, port, user name, and password " +
-                    "for the IBM IMS server of your choice.",
-                properties: {
-                    host: {
-                        type: "string",
-                        optionDefinition: {
-                            name: "host",
-                            aliases: ["H"],
-                            description: "The IMS server host name",
-                            type: "string",
-                            required: true,
-                        },
-                    },
-                    port: {
-                        type: "number",
-                        optionDefinition: {
-                            name: "port",
-                            aliases: ["P"],
-                            description: "The IMS server port",
-                            type: "number",
-                            defaultValue: 1490,
-                        },
-                    },
-                    user: {
-                        type: "string",
-                        secure: true,
-                        optionDefinition: {
-                            name: "user",
-                            aliases: ["u"],
-                            description: "Your username to connect to IMS",
-                            type: "string",
-                            implies: ["password"],
-                            required: true,
-                        },
-                    },
-                    password: {
-                        type: "string",
-                        secure: true,
-                        optionDefinition: {
-                            name: "password",
-                            aliases: ["p"],
-                            description: "Your password to connect to IMS",
-                            type: "string",
-                            implies: ["user"],
-                            required: true,
-                        },
-                    }
-                },
-                required: ["host"],
+  commandModuleGlobs: ["**/cli/*/*.definition!(.d).*s"],
+  rootCommandDescription: PluginConstants.PLUGIN_DESCRIPTION,
+  productDisplayName: PluginConstants.PLUGIN_NAME,
+  name: PluginConstants.PLUGIN_GROUP_NAME,
+  profiles: [
+    {
+      type: "ims",
+      schema: {
+        type: "object",
+        title: "IMS Profile",
+        description: "A ims profile is required to issue commands in the ims command group that interact with " +
+          "IMS regions. The ims profile contains your host, port, user name, and password " +
+          "for the IBM IMS server of your choice.",
+        properties: {
+          host: {
+            type: "string",
+            optionDefinition: {
+              name: "host",
+              aliases: ["H"],
+              description: "The IMS server host name",
+              type: "string",
+              required: true,
             },
-            createProfileExamples: [
-                {
-                    options: "ims123 --host zos123 --port 1490 --user ibmuser --password myp4ss",
-                    description: "Create a ims profile named 'ims123' to connect to IMS at host zos123 and port 1490"
-                }
-            ]
+          },
+          port: {
+            type: "number",
+            optionDefinition: {
+              name: "port",
+              aliases: ["P"],
+              description: "The IMS server port",
+              type: "number",
+              defaultValue: 1490,
+            },
+          },
+          user: {
+            type: "string",
+            secure: true,
+            optionDefinition: {
+              name: "user",
+              aliases: ["u"],
+              description: "Your username to connect to IMS",
+              type: "string",
+              implies: ["password"],
+              required: true,
+            },
+          },
+          password: {
+            type: "string",
+            secure: true,
+            optionDefinition: {
+              name: "password",
+              aliases: ["p"],
+              description: "Your password to connect to IMS",
+              type: "string",
+              implies: ["user"],
+              required: true,
+            },
+          }
+        },
+        required: ["host"],
+      },
+      createProfileExamples: [
+        {
+          options: "ims123 --host zos123 --port 1490 --user ibmuser --password myp4ss",
+          description: "Create a ims profile named 'ims123' to connect to IMS at host zos123 and port 1490"
         }
-    ]
+      ]
+    }
+  ],
+  pluginHealthCheck: __dirname + "/healthCheck"
 };
 
 export = config;


### PR DESCRIPTION
Update most references to CICS to IMS (still says CMCI but wasn't sure what to change it to, we can always revisit)
The health check prevents a warning when validating the IMS plugin