### PR TITLE
Remove CLI peer dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the IBM® IMS™ Plug-in for Zowe CLI will be documented in this file.
 
+## Recent Changes
+
+- Remove @zowe/cli peer dependency to better support NPM v7
+
 ## `2.0.1`
 
 - Remove warnings at install time

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "configurationModule": "lib/imperative.js"
   },
   "peerDependencies": {
-    "@zowe/cli": "7.0.0-next.202103152050",
     "@zowe/imperative": "5.0.0-next.202104071400"
   },
   "devDependencies": {


### PR DESCRIPTION
Remove @zowe/cli peer dependency to better support NPM v7

Signed-off-by: Andrew W. Harn <andrew.harn@broadcom.com>