### PR TITLE
Apiml conn lookup next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the IBM® IMS™ Plug-in for Zowe CLI will be documented in this file.
 
+## Recent Changes
+
+- Enhancement: Add apimlConnLookup properties to enable auto-config through APIML. A valid apiId must still be identified.
+
 ## `3.0.0-next.202106071926`
 
 - **Breaking**: Removed the previously deprecated function ImsRestClient.performRest(). The function ImsRestClient.request() must now be used.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ node('zowe-jenkins-agent') {
     // Protected branch property definitions
     pipeline.protectedBranches.addMap([
         [name: "master", tag: "latest", aliasTags: ["zowe-v1-lts"], devDependencies: ["@zowe/imperative": "zowe-v1-lts"], level: SemverLevel.MINOR],
-        [name: "next", tag: "next", prerelease: "next", devDependencies: ["@zowe/imperative": "next"]],
+        [name: "next", tag: "next", prerelease: "next"],
         //[name: "master", tag: "latest", devDependencies: ["@zowe/imperative": "latest"]],
         //[name: "zowe-v1-lts", tag: "zowe-v1-lts", devDependencies: ["@zowe/imperative": "zowe-v1-lts"], level: SemverLevel.MINOR]
         [name: "lts-incremental", tag: "lts-incremental", devDependencies: ["@zowe/imperative" :"lts-incremental"], level: SemverLevel.PATCH]

--- a/__tests__/__snapshots__/imperative.test.ts.snap
+++ b/__tests__/__snapshots__/imperative.test.ts.snap
@@ -2,6 +2,13 @@
 
 exports[`imperative config should match the snapshot 1`] = `
 Object {
+  "apimlConnLookup": Array [
+    Object {
+      "apiId": "place_the_ims_apiId_here",
+      "connProfType": "ims",
+      "gatewayUrl": "api/v1",
+    },
+  ],
   "commandModuleGlobs": Array [
     "**/cli/*/*.definition!(.d).*s",
   ],

--- a/package.json
+++ b/package.json
@@ -43,14 +43,14 @@
     "configurationModule": "lib/imperative.js"
   },
   "peerDependencies": {
-    "@zowe/imperative": ">=5.0.0-next.202106041929 <5.0.0"
+    "@zowe/imperative": ">=5.0.0-next.202106221817 <5.0.0"
   },
   "devDependencies": {
     "@types/fs-extra": "^8.1.1",
     "@types/jest": "^20.0.5",
     "@types/node": "^8.10.66",
     "@types/yargs": "13.0.4",
-    "@zowe/imperative": "^5.0.0-next.202106041929",
+    "@zowe/imperative": ">=5.0.0-next <6.0.0",
     "env-cmd": "^8.0.2",
     "fs-extra": "^5.0.0",
     "glob": "^7.1.6",

--- a/src/imperative.ts
+++ b/src/imperative.ts
@@ -19,6 +19,13 @@ const config: IImperativeConfig = {
     rootCommandDescription: PluginConstants.PLUGIN_DESCRIPTION,
     productDisplayName: PluginConstants.PLUGIN_NAME,
     name: PluginConstants.PLUGIN_GROUP_NAME,
+    apimlConnLookup: [
+        {
+          apiId: "place_the_ims_apiId_here",
+          gatewayUrl: "api/v1",
+          connProfType: "ims"
+        }
+    ],
     profiles: [
         {
             type: "ims",


### PR DESCRIPTION
Add apimlConnLookup properties to enable auto-config through APIML.
A valid apiId for IMS must still be identified.